### PR TITLE
Mock pull request to fix issue #181207

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -767,9 +767,8 @@ export class ExtensionEditor extends EditorPane {
 				<style nonce="${nonce}">
 					${DEFAULT_MARKDOWN_STYLES}
 
-					/* prevent scroll-to-top button from blocking the body text */
 					body {
-						padding-bottom: 75px;
+						padding-bottom: 57px; /* 25 + 32 */
 					}
 
 					#scroll-to-top {


### PR DESCRIPTION
Added padding to bottom of extensions preview page to prevent scroll to top button from covering the text when scrolled all the way down. 

https://github.com/microsoft/vscode/issues/181207

Before:
![image](https://github.com/antoniacobaeus/vscode/assets/46004494/becfa583-d8ed-4964-ae36-45dfa10f402d)

After:
![image](https://github.com/antoniacobaeus/vscode/assets/46004494/1821ee93-ac58-40ed-b68b-ee1cb53e6ebf)
